### PR TITLE
Gives support for the WASD keys -- AZERTY-friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,35 @@
     document.addEventListener("keydown", keyDownHandler, false);
     document.addEventListener("keyup", keyUpHandler, false);
     function keyDownHandler(e) {
+        if ("code" in e) {
+            switch(e.code) {
+                case "Unidentified":
+                    break;
+                case "ArrowRight":
+                case "Right": // IE <= 9 and FF <= 36
+                case "KeyD":
+                    rightPressed = true;
+                    return;
+                case "ArrowLeft":
+                case "Left": // IE <= 9 and FF <= 36
+                case "KeyA":
+                    leftPressed = true;
+                    return;
+                case "ArrowUp":
+                case "Up": // IE <= 9 and FF <= 36
+                case "KeyW":
+                    upPressed = true;
+                    return;
+                case "ArrowDown":
+                case "Down": // IE <= 9 and FF <= 36
+                case "KeyS":
+                    downPressed = true;
+                    return;
+                default:
+                    return;
+            }
+        }
+
         if(e.keyCode == 39) {
             rightPressed = true;
         }
@@ -43,6 +72,35 @@
         }
     }
     function keyUpHandler(e) {
+        if ("code" in e) {
+            switch(e.code) {
+                case "Unidentified":
+                    break;
+                case "ArrowRight":
+                case "Right": // IE <= 9 and FF <= 36
+                case "KeyD":
+                    rightPressed = false;
+                    return;
+                case "ArrowLeft":
+                case "Left": // IE <= 9 and FF <= 36
+                case "KeyA":
+                    leftPressed = false;
+                    return;
+                case "ArrowUp":
+                case "Up": // IE <= 9 and FF <= 36
+                case "KeyW":
+                    upPressed = false;
+                    return;
+                case "ArrowDown":
+                case "Down": // IE <= 9 and FF <= 36
+                case "KeyS":
+                    downPressed = false;
+                    return;
+                default:
+                    return;
+            }
+        }
+
         if(e.keyCode == 39) {
             rightPressed = false;
         }


### PR DESCRIPTION
Supports the WASD keys using the DOM KeyboardEvent level 3 property `code`. It works for me on a AZERTY keyboard on Firefox 51 and Chromium 53 on Linux, but I haven't tried on other browsers/platforms/keyboard layout, so please try :)